### PR TITLE
Add Codex CLI worker endpoint for Workers AI

### DIFF
--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -311,3 +311,35 @@ export async function handleCompletionsWithMemory(request: Request, env: Env, co
         });
     }
 }
+
+/**
+ * Provides a catalogue of notable API endpoints exposed by this worker. This is primarily
+ * used for documentation and tooling that dynamically renders available endpoints.
+ */
+export const REGISTERED_ENDPOINTS = [
+    {
+        endpoint: '/v1/models',
+        name: 'Model Catalogue',
+        provider: 'multi-provider'
+    },
+    {
+        endpoint: '/v1/completions',
+        name: 'Legacy Completions',
+        provider: 'openai-compatible'
+    },
+    {
+        endpoint: '/v1/completions/withmemory',
+        name: 'Completions with Memory',
+        provider: 'openai-compatible'
+    },
+    {
+        endpoint: '/test/apis',
+        name: 'Diagnostics',
+        provider: 'internal'
+    },
+    {
+        endpoint: '/codex/workers-ai/:model',
+        name: 'Codex Direct Handler',
+        provider: 'codex'
+    }
+];

--- a/src/handlers/codex.ts
+++ b/src/handlers/codex.ts
@@ -1,0 +1,180 @@
+/**
+ * @file src/handlers/codex.ts
+ * @description Handler for Codex CLI requests that routes them directly to Workers AI
+ *              without using the AI Gateway. The handler parses the native Codex
+ *              payload, normalizes it into a Workers AI compatible format, and streams
+ *              the response back to the client.
+ */
+
+import type { CodexRequestBody, OpenAIMessage, Env } from '../types';
+
+const CODEX_ROUTE_PATTERN = /^\/codex\/workers-ai\/([^/]+)$/;
+
+/**
+ * Transforms a Codex-style request payload into the simplified messages format expected
+ * by Workers AI. System prompts are concatenated together, user prompts are combined into
+ * a single entry, and assistant messages are preserved in their original order.
+ */
+export function transformCodexToWorkerMessages(codexRequest: CodexRequestBody): OpenAIMessage[] {
+        const messages: OpenAIMessage[] = [];
+        let systemBuffer = '';
+        const userBuffer: string[] = [];
+
+        const flushSystem = () => {
+                if (systemBuffer.trim().length > 0) {
+                        messages.push({ role: 'system', content: systemBuffer.trim() });
+                        systemBuffer = '';
+                }
+        };
+
+        const flushUser = () => {
+                if (userBuffer.length > 0) {
+                        messages.push({ role: 'user', content: userBuffer.join('\n\n') });
+                        userBuffer.length = 0;
+                }
+        };
+
+        for (const message of codexRequest.messages) {
+                switch (message.role) {
+                        case 'system':
+                                systemBuffer = systemBuffer ? `${systemBuffer}\n\n${message.content}` : message.content;
+                                break;
+                        case 'user':
+                                userBuffer.push(message.content);
+                                break;
+                        case 'assistant':
+                                flushSystem();
+                                flushUser();
+                                messages.push({ role: 'assistant', content: message.content });
+                                break;
+                        default:
+                                break;
+                }
+        }
+
+        flushSystem();
+        flushUser();
+
+        return messages;
+}
+
+function deriveModelName(request: Request, providedModel?: string): string | null {
+        if (providedModel) {
+                return providedModel;
+        }
+
+        const match = new URL(request.url).pathname.match(CODEX_ROUTE_PATTERN);
+        if (match?.[1]) {
+                return match[1];
+        }
+
+        return null;
+}
+
+function applyCorsHeaders(headers: Headers, corsHeaders?: Record<string, string>): void {
+        if (!corsHeaders) {
+                return;
+        }
+
+        for (const [key, value] of Object.entries(corsHeaders)) {
+                headers.set(key, value);
+        }
+}
+
+/**
+ * Handles incoming Codex CLI requests and proxies them directly to Workers AI by using
+ * the bound `env.AI` service. The model identifier is derived from the request URL and
+ * the payload is transformed to the format required by `env.AI.run`.
+ */
+export async function handleCodexRequest(
+        request: Request,
+        env: Env,
+        modelFromRoute?: string,
+        corsHeaders?: Record<string, string>
+): Promise<Response> {
+        if (request.method !== 'POST') {
+                const headers = new Headers({ 'Content-Type': 'application/json' });
+                applyCorsHeaders(headers, corsHeaders);
+                return new Response(JSON.stringify({ error: 'Method Not Allowed' }), { status: 405, headers });
+        }
+
+        try {
+                const codexRequest = await request.json<CodexRequestBody>();
+                const modelName = deriveModelName(request, modelFromRoute) || codexRequest.model;
+
+                if (!modelName) {
+                        const headers = new Headers({ 'Content-Type': 'application/json' });
+                        applyCorsHeaders(headers, corsHeaders);
+                        return new Response(JSON.stringify({ error: 'Model not specified in URL path or request body.' }), {
+                                status: 400,
+                                headers,
+                        });
+                }
+
+                if (!env.CLOUDFLARE_ACCOUNT_ID) {
+                        const headers = new Headers({ 'Content-Type': 'application/json' });
+                        applyCorsHeaders(headers, corsHeaders);
+                        return new Response(JSON.stringify({ error: 'CLOUDFLARE_ACCOUNT_ID is not configured.' }), {
+                                status: 500,
+                                headers,
+                        });
+                }
+
+                if (!env.AI) {
+                        const headers = new Headers({ 'Content-Type': 'application/json' });
+                        applyCorsHeaders(headers, corsHeaders);
+                        return new Response(JSON.stringify({ error: 'AI binding is not configured.' }), {
+                                status: 500,
+                                headers,
+                        });
+                }
+
+                const messages = transformCodexToWorkerMessages(codexRequest);
+                const payload: Record<string, unknown> = {
+                        messages,
+                        stream: codexRequest.stream ?? false,
+                };
+
+                if (Array.isArray(codexRequest.tools) && codexRequest.tools.length > 0) {
+                        payload.tools = codexRequest.tools;
+                }
+
+                const modelIdentifier = modelName.startsWith('@cf/')
+                        ? modelName
+                        : `@cf/${env.CLOUDFLARE_ACCOUNT_ID}/${modelName}`;
+
+                const aiResponse = await env.AI.run(modelIdentifier, payload);
+
+                if (codexRequest.stream) {
+                        const headers = new Headers({ 'Content-Type': 'application/x-ndjson' });
+                        applyCorsHeaders(headers, corsHeaders);
+
+                        if (aiResponse instanceof ReadableStream) {
+                                return new Response(aiResponse, { headers });
+                        }
+
+                        const body = typeof aiResponse === 'string' ? aiResponse : JSON.stringify(aiResponse);
+                        return new Response(body, { headers });
+                }
+
+                const headers = new Headers({ 'Content-Type': 'application/json' });
+                applyCorsHeaders(headers, corsHeaders);
+                const body = typeof aiResponse === 'string' ? aiResponse : JSON.stringify(aiResponse);
+                return new Response(body, { headers });
+        } catch (error) {
+                console.error('Error handling Codex request:', error);
+                const headers = new Headers({ 'Content-Type': 'application/json' });
+                applyCorsHeaders(headers, corsHeaders);
+                const message = error instanceof Error ? error.message : 'An unexpected error occurred.';
+                return new Response(
+                        JSON.stringify({ error: 'Invalid request body or processing error.', details: message }),
+                        { status: 400, headers },
+                );
+        }
+}
+
+export function extractCodexModelFromPath(pathname: string): string | null {
+        const match = pathname.match(CODEX_ROUTE_PATTERN);
+        return match?.[1] ?? null;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
 
 import { authenticateRequest } from './auth';
 import { handleCompletions, handleCompletionsWithMemory, handleModelsRequest, handleTestAPIs } from './endpoints';
-import { handleChatCompletions, handleStructuredChatCompletions, handleTextChatCompletions } from './routing';
+import { handleChatCompletions, handleStructuredChatCompletions, handleTextChatCompletions, handleCodexRoute } from './routing';
 import { debugLog, errorLog, generateId } from './utils';
 
 export default {
@@ -96,10 +96,15 @@ export default {
 					headers: { 'Content-Type': 'application/json', ...corsHeaders },
 				});
 			}
-			debugLog(env, 'Authentication successful');
+                        debugLog(env, 'Authentication successful');
 
-			// Route API requests to their respective handlers.
-			switch (path) {
+                        const codexResponse = await handleCodexRoute(request, env, corsHeaders);
+                        if (codexResponse) {
+                                return codexResponse;
+                        }
+
+                        // Route API requests to their respective handlers.
+                        switch (path) {
 				case '/v1/chat/completions':
 					return handleChatCompletions(request, env, corsHeaders);
 				case '/v1/chat/completions/structured':

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -8,7 +8,7 @@
  *              standard, structured (JSON), and text-only.
  */
 
-import type { ChatCompletionRequestBody } from './types';
+import type { ChatCompletionRequestBody, Env } from './types';
 import { debugLog, errorLog } from './utils';
 import { addMemoryContext, saveMemoryContext } from './memory';
 import { detectProvider, getModelType, mapModelName } from './models';
@@ -16,6 +16,19 @@ import { handleOpenAIRequest, handleOpenAIStructuredRequest, handleOpenAITextReq
 import { handleGeminiRequest, handleGeminiStructuredRequest, handleGeminiTextRequest } from './handlers/gemini';
 import { handleCloudflareTextRequest, handleCloudflareStructuredRequest } from './handlers/cloudflare';
 import { supportsStructuredOutputs, getAvailableStructuredModels } from './handlers/model-info';
+import { handleCodexRequest } from './handlers/codex';
+
+const CODEX_ROUTE_REGEX = /^\/codex\/workers-ai\/([^/]+)$/;
+
+export async function handleCodexRoute(request: Request, env: Env, corsHeaders: Record<string, string>): Promise<Response | null> {
+    const match = new URL(request.url).pathname.match(CODEX_ROUTE_REGEX);
+    if (!match) {
+        return null;
+    }
+
+    const model = match[1];
+    return handleCodexRequest(request, env, model, corsHeaders);
+}
 
 /**
  * Validates if a model supports structured outputs and returns an error response if not.

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,5 +158,88 @@ export interface CloudflareAIModel {
  *   (e.g., 'meta', 'openai') and values are arrays of model details for that provider.
  */
 export interface CloudflareAIModelsResponse {
-	providers: Record<string, CloudflareAIModel[]>;
+        providers: Record<string, CloudflareAIModel[]>;
 }
+
+// --- Shared Message Types ---
+
+/**
+ * Represents a generic OpenAI-style chat message used across different handlers.
+ */
+export type OpenAIMessage = ChatMessage;
+
+/**
+ * Represents a single Gemini message part, which is primarily text-based in this worker.
+ */
+export interface GeminiMessagePart {
+        text: string;
+}
+
+/**
+ * Represents a single message entry in a Gemini request payload.
+ */
+export interface GeminiMessage {
+        role: 'user' | 'model';
+        parts: GeminiMessagePart[];
+}
+
+/**
+ * Represents the full request body when interacting with Gemini models.
+ */
+export interface GeminiRequest {
+        contents: GeminiMessage[];
+}
+
+// --- Codex CLI Request Types ---
+
+/**
+ * Represents a single message entry in the Codex CLI payload.
+ */
+export interface CodexMessage {
+        role: 'system' | 'user' | 'assistant';
+        content: string;
+}
+
+/**
+ * Describes the shape of a function tool in the Codex payload.
+ */
+export interface CodexToolFunction {
+        parameters: Record<string, unknown>;
+        name: string;
+        description: string;
+        strict?: boolean;
+}
+
+/**
+ * Represents a tool entry in the Codex payload.
+ */
+export interface CodexTool {
+        type: 'function';
+        function: CodexToolFunction;
+}
+
+/**
+ * Defines the top-level request body sent by the Codex CLI.
+ */
+export interface CodexRequestBody {
+        model: string;
+        messages: CodexMessage[];
+        stream?: boolean;
+        tools?: CodexTool[];
+        [key: string]: unknown;
+}
+
+// --- Environment Bindings ---
+
+declare global {
+        interface Env {
+                AI: any;
+                DB: D1Database;
+                KV: KVNamespace;
+                AUTH_KEY_SECRET: string;
+                CLOUDFLARE_ACCOUNT_ID: string;
+                // Add other environment variables here.
+        }
+}
+
+export type Env = globalThis.Env;


### PR DESCRIPTION
## Summary
- add Codex-specific request types and augment the worker bindings with the Workers AI account id
- implement a dedicated Codex handler that normalizes Codex CLI payloads and streams results from env.AI.run
- register the Codex route in the router, main fetch entry point, and endpoint catalogue for discoverability

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68d011208520832e97f9b15d8eb13cda