### PR TITLE
Add structured response tabs and downloadable Python helpers

### DIFF
--- a/static/downloads.html
+++ b/static/downloads.html
@@ -171,7 +171,7 @@
         <div class="content">
             <div class="intro">
                 <p>Each download includes a helper that ensures a local <code>.env</code> file contains <code>WORKER_URL</code> and <code>WORKER_API_KEY</code>. The default URL is populated for you—just edit the key.</p>
-                <p>Place the downloaded script in a project folder, run it with Python 3.9+, and install dependencies with <code>pip install requests</code> (plus <code>sqlite3</code> from the standard library).</p>
+                <p>Place the downloaded script in a project folder, run it with Python 3.9+, and install dependencies with <code>pip install requests</code>. The advanced client also uses the <code>sqlite3</code> module, which is part of the Python standard library and does not require installation.</p>
             </div>
 
             <div class="download-grid">

--- a/static/downloads.html
+++ b/static/downloads.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Download Python Modules · OpenAI API Worker</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+        }
+
+        a {
+            color: inherit;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 30px 20px 60px;
+        }
+
+        .header {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+            border-radius: 20px;
+            padding: 40px;
+            margin-bottom: 30px;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+        }
+
+        .header h1 {
+            font-size: 2.6rem;
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            margin-bottom: 10px;
+        }
+
+        .nav {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .nav a {
+            padding: 10px 18px;
+            border-radius: 8px;
+            background: rgba(102, 126, 234, 0.12);
+            color: #334155;
+            font-weight: 600;
+            text-decoration: none;
+            transition: all 0.3s ease;
+        }
+
+        .nav a:hover {
+            background: rgba(102, 126, 234, 0.2);
+        }
+
+        .content {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+            border-radius: 20px;
+            padding: 40px;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+        }
+
+        .intro {
+            margin-bottom: 30px;
+        }
+
+        .intro p {
+            margin-bottom: 10px;
+        }
+
+        .download-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 20px;
+        }
+
+        .card {
+            border: 1px solid rgba(102, 126, 234, 0.2);
+            border-radius: 16px;
+            padding: 24px;
+            background: white;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            box-shadow: 0 10px 18px rgba(102, 126, 234, 0.12);
+        }
+
+        .card h2 {
+            font-size: 1.3rem;
+            color: #4338ca;
+        }
+
+        .card ul {
+            margin-left: 20px;
+            color: #475569;
+        }
+
+        .card ul li {
+            margin-bottom: 6px;
+        }
+
+        .download-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 18px;
+            border-radius: 8px;
+            background: #667eea;
+            color: white;
+            font-weight: 600;
+            text-decoration: none;
+            transition: background 0.3s ease;
+        }
+
+        .download-btn:hover {
+            background: #5a67d8;
+        }
+
+        .note {
+            margin-top: 30px;
+            padding: 20px;
+            border-radius: 12px;
+            background: rgba(102, 126, 234, 0.12);
+            color: #1f2937;
+        }
+
+        code {
+            background: rgba(15, 23, 42, 0.08);
+            padding: 2px 6px;
+            border-radius: 4px;
+        }
+
+        @media (max-width: 768px) {
+            .header h1 {
+                font-size: 2rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>⬇️ Download Python Modules</h1>
+            <p>Pre-built clients that connect to your OpenAI-compatible worker, complete with environment setup helpers.</p>
+        </div>
+
+        <div class="nav">
+            <a href="/">← Back to Overview</a>
+            <a href="/openapi.json" target="_blank" rel="noopener noreferrer">OpenAPI Spec</a>
+            <a href="https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/" target="_blank" rel="noopener noreferrer">Llama 4 Docs</a>
+        </div>
+
+        <div class="content">
+            <div class="intro">
+                <p>Each download includes a helper that ensures a local <code>.env</code> file contains <code>WORKER_URL</code> and <code>WORKER_API_KEY</code>. The default URL is populated for you—just edit the key.</p>
+                <p>Place the downloaded script in a project folder, run it with Python 3.9+, and install dependencies with <code>pip install requests</code> (plus <code>sqlite3</code> from the standard library).</p>
+            </div>
+
+            <div class="download-grid">
+                <div class="card">
+                    <h2>Python Basic</h2>
+                    <p>A minimal example that sends a chat completion request using Workers AI through this worker.</p>
+                    <ul>
+                        <li>Ensures the <code>.env</code> file exists</li>
+                        <li>Calls <code>/v1/chat/completions</code> with Llama 4 Scout</li>
+                        <li>Prints the assistant response to the console</li>
+                    </ul>
+                    <a class="download-btn" href="/downloads/python-basic.py" download>Download python-basic.py</a>
+                </div>
+
+                <div class="card">
+                    <h2>Python Structured Response</h2>
+                    <p>Request JSON-safe answers from <code>@cf/meta/llama-4-scout-17b-16e-instruct</code> using <code>response_format</code>.</p>
+                    <ul>
+                        <li>Auto-creates or updates <code>.env</code></li>
+                        <li>Demonstrates JSON schema validation</li>
+                        <li>Parses the structured payload into Python objects</li>
+                    </ul>
+                    <a class="download-btn" href="/downloads/python-structured-llama4.py" download>Download python-structured-llama4.py</a>
+                </div>
+
+                <div class="card">
+                    <h2>Python Agentic Patterns</h2>
+                    <p>Showcases tool-calling loops for function-style automation using Workers AI.</p>
+                    <ul>
+                        <li>Mocks tool results locally</li>
+                        <li>Feeds tool outputs back into the conversation</li>
+                        <li>Highlights multi-turn agent orchestration</li>
+                    </ul>
+                    <a class="download-btn" href="/downloads/python-agentic-patterns.py" download>Download python-agentic-patterns.py</a>
+                </div>
+
+                <div class="card">
+                    <h2>Python Advanced Client</h2>
+                    <p>A reusable class with file helpers, SQLite utilities, and structured-response helpers.</p>
+                    <ul>
+                        <li>Default model: <code>@cf/openai/gpt-oss-120b</code></li>
+                        <li>Loads system instructions from disk</li>
+                        <li>Includes <code>structured_llama4</code> and code-fence cleanup utilities</li>
+                    </ul>
+                    <a class="download-btn" href="/downloads/python-advanced-worker-client.py" download>Download python-advanced-worker-client.py</a>
+                </div>
+            </div>
+
+            <div class="note">
+                <strong>Tip:</strong> After downloading, open the generated <code>.env</code> file and set <code>WORKER_API_KEY</code>. Keep the key secret—never commit it to version control.
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/static/downloads/python-advanced-worker-client.py
+++ b/static/downloads/python-advanced-worker-client.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Advanced Worker AI client featuring file and SQLite helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+
+DEFAULT_WORKER_URL = "https://your-worker-url.example.com"
+ENV_PATH = Path(__file__).resolve().parent / ".env"
+
+
+class WorkerAIClient:
+    """A high-level client for interacting with the OpenAI-compatible worker."""
+
+    def __init__(self, model: str = "@cf/openai/gpt-oss-120b") -> None:
+        self.model = model
+        self.env_values = self.load_env()
+        self.worker_url = self.env_values.get("WORKER_URL", DEFAULT_WORKER_URL).rstrip("/")
+        self.api_key = self.env_values.get("WORKER_API_KEY")
+        self.system_instruction: str = "You are a pragmatic assistant."
+
+    @staticmethod
+    def ensure_env_file(path: Path = ENV_PATH) -> None:
+        defaults: Dict[str, str] = {
+            "WORKER_URL": DEFAULT_WORKER_URL,
+            "WORKER_API_KEY": "",
+        }
+
+        if not path.exists():
+            path.write_text(
+                "# Environment settings for the OpenAI-compatible worker\n"
+                "WORKER_URL={url}\n"
+                "WORKER_API_KEY=\n".format(url=defaults["WORKER_URL"]),
+                encoding="utf-8",
+            )
+            return
+
+        existing_keys = {
+            line.split("=", 1)[0].strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line and not line.strip().startswith("#") and "=" in line
+        }
+
+        with path.open("a", encoding="utf-8") as handle:
+            if "WORKER_URL" not in existing_keys:
+                handle.write(f"\nWORKER_URL={defaults['WORKER_URL']}")
+            if "WORKER_API_KEY" not in existing_keys:
+                handle.write("\nWORKER_API_KEY=")
+
+    @classmethod
+    def load_env(cls, path: Path = ENV_PATH) -> Dict[str, str]:
+        cls.ensure_env_file(path)
+        values: Dict[str, str] = {}
+
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line or line.strip().startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            cleaned = value.strip().strip('"').strip("'")
+            os.environ.setdefault(key.strip(), cleaned)
+            values[key.strip()] = cleaned
+
+        return values
+
+    def require_api_key(self) -> None:
+        if not self.api_key:
+            raise RuntimeError(
+                "WORKER_API_KEY is missing. Update the .env file next to this script with your secret."
+            )
+
+    def set_system_instruction_from_file(self, path: str) -> None:
+        content = Path(path).read_text(encoding="utf-8")
+        self.system_instruction = content.strip() or self.system_instruction
+
+    def call_model(self, messages: List[Dict[str, Any]], **options: Any) -> Dict[str, Any]:
+        self.require_api_key()
+        endpoint = f"{self.worker_url}/v1/chat/completions"
+        payload = {"model": options.pop("model", self.model), "messages": messages}
+        payload.update(options)
+
+        response = requests.post(
+            endpoint,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=120,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def ask(self, prompt: str, **options: Any) -> str:
+        messages = [
+            {"role": "system", "content": self.system_instruction},
+            {"role": "user", "content": prompt},
+        ]
+        result = self.call_model(messages, **options)
+        return self._extract_content(result)
+
+    def structured_llama4(self, prompt: str) -> Dict[str, Any]:
+        schema = {
+            "type": "object",
+            "properties": {
+                "topic": {"type": "string"},
+                "key_points": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 3,
+                },
+                "next_step": {"type": "string"},
+            },
+            "required": ["topic", "key_points", "next_step"],
+            "additionalProperties": False,
+        }
+
+        messages = [
+            {"role": "system", "content": "You return JSON strictly following the schema."},
+            {"role": "user", "content": prompt},
+        ]
+        result = self.call_model(
+            messages,
+            model="@cf/meta/llama-4-scout-17b-16e-instruct",
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "insight_packet",
+                    "schema": schema,
+                },
+            },
+        )
+        message = result.get("choices", [{}])[0].get("message", {})
+        structured = message.get("parsed") or message.get("content") or {}
+        if isinstance(structured, str):
+            try:
+                structured = json.loads(self.strip_code_fences(structured))
+            except json.JSONDecodeError:
+                structured = {"raw": structured}
+        return structured
+
+    @staticmethod
+    def strip_code_fences(text: str) -> str:
+        if not text:
+            return ""
+        cleaned = text.strip()
+        for fence in ("```", "~~~"):
+            if cleaned.startswith(fence) and cleaned.endswith(fence):
+                inner = cleaned[len(fence):-len(fence)].strip()
+                if "\n" in inner:
+                    language, body = inner.split("\n", 1)
+                    if language.strip() and not body.strip():
+                        cleaned = language
+                    else:
+                        cleaned = body
+                else:
+                    cleaned = inner
+                break
+        return cleaned.strip()
+
+    def read_local_file(self, path: str) -> str:
+        return Path(path).read_text(encoding="utf-8")
+
+    def save_local_file(self, path: str, content: str) -> None:
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
+
+    def read_sqlite(self, db_path: str, query: str, params: Optional[Iterable[Any]] = None) -> List[Dict[str, Any]]:
+        connection = sqlite3.connect(db_path)
+        connection.row_factory = sqlite3.Row
+        try:
+            cursor = connection.execute(query, params or [])
+            rows = cursor.fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            connection.close()
+
+    def append_sqlite(self, db_path: str, table: str, data: Dict[str, Any]) -> None:
+        connection = sqlite3.connect(db_path)
+        try:
+            columns = ", ".join(data.keys())
+            placeholders = ", ".join(["?"] * len(data))
+            connection.execute(
+                f"INSERT INTO {table} ({columns}) VALUES ({placeholders})",
+                tuple(data.values()),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def _extract_content(self, response: Dict[str, Any]) -> str:
+        message = response.get("choices", [{}])[0].get("message", {})
+        content = message.get("content")
+        if isinstance(content, str):
+            return self.strip_code_fences(content)
+        return json.dumps(message, indent=2)
+
+
+def demo() -> None:
+    client = WorkerAIClient()
+    try:
+        summary = client.ask("List two benefits of edge inference.")
+        print("Chat completion:\n", summary)
+
+        structured = client.structured_llama4("Share deployment insights for Workers AI.")
+        print("\nStructured response:\n", json.dumps(structured, indent=2))
+
+        client.save_local_file("./artifacts/notes.txt", "Edge inference keeps latency low.\n")
+        print("\nSaved notes to ./artifacts/notes.txt")
+
+    except RuntimeError as error:
+        print(error)
+
+
+if __name__ == "__main__":
+    demo()

--- a/static/downloads/python-agentic-patterns.py
+++ b/static/downloads/python-agentic-patterns.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Demonstrate tool-augmented agentic patterns with the worker AI."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+
+DEFAULT_WORKER_URL = "https://your-worker-url.example.com"
+ENV_PATH = Path(__file__).resolve().parent / ".env"
+
+
+def ensure_env_file(path: Path = ENV_PATH) -> None:
+    defaults: Dict[str, str] = {
+        "WORKER_URL": DEFAULT_WORKER_URL,
+        "WORKER_API_KEY": "",
+    }
+
+    if not path.exists():
+        path.write_text(
+            "# Environment settings for the OpenAI-compatible worker\n"
+            "WORKER_URL={url}\n"
+            "WORKER_API_KEY=\n".format(url=defaults["WORKER_URL"]),
+            encoding="utf-8",
+        )
+        return
+
+    existing_keys = {
+        line.split("=", 1)[0].strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line and not line.strip().startswith("#") and "=" in line
+    }
+
+    with path.open("a", encoding="utf-8") as handle:
+        if "WORKER_URL" not in existing_keys:
+            handle.write(f"\nWORKER_URL={defaults['WORKER_URL']}")
+        if "WORKER_API_KEY" not in existing_keys:
+            handle.write("\nWORKER_API_KEY=")
+
+
+def load_env(path: Path = ENV_PATH) -> Dict[str, str]:
+    ensure_env_file(path)
+    values: Dict[str, str] = {}
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.strip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        clean_value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key.strip(), clean_value)
+        values[key.strip()] = clean_value
+
+    return values
+
+
+def call_worker(messages: List[dict], tools: List[dict]) -> dict:
+    env_values = load_env()
+    worker_url = env_values.get("WORKER_URL", DEFAULT_WORKER_URL).rstrip("/")
+    api_key = env_values.get("WORKER_API_KEY")
+
+    if not api_key:
+        raise RuntimeError("WORKER_API_KEY is missing. Set it inside .env next to this script.")
+
+    endpoint = f"{worker_url}/v1/chat/completions"
+    response = requests.post(
+        endpoint,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": "@cf/meta/llama-4-scout-17b-16e-instruct",
+            "messages": messages,
+            "tools": tools,
+        },
+        timeout=90,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def mock_weather(city: str) -> Dict[str, str]:
+    temperatures = random.randint(18, 32)
+    return {
+        "city": city,
+        "temperature_c": temperatures,
+        "condition": random.choice(["sunny", "cloudy", "rain showers"]),
+    }
+
+
+def mock_document_search(query: str) -> Dict[str, List[str]]:
+    return {
+        "query": query,
+        "results": [
+            "Workers AI supports OpenAI-compatible APIs at the edge.",
+            "Structured responses provide JSON with schema guarantees.",
+        ],
+    }
+
+
+def run_agentic_demo() -> None:
+    messages: List[dict] = [
+        {
+            "role": "system",
+            "content": "You are a research assistant that plans tasks and uses tools before answering.",
+        },
+        {
+            "role": "user",
+            "content": "Plan a weekend in Porto with a quick weather check and relevant reading list.",
+        },
+    ]
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Retrieve the current weather outlook for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                    },
+                    "required": ["city"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "search_docs",
+                "description": "Search internal docs for planning context.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                    },
+                    "required": ["query"],
+                },
+            },
+        },
+    ]
+
+    while True:
+        response = call_worker(messages, tools)
+        message = response.get("choices", [{}])[0].get("message", {})
+        tool_calls = message.get("tool_calls", [])
+
+        if not tool_calls:
+            print("\nFinal assistant response:\n")
+            print(message.get("content", "No content returned."))
+            break
+
+        for call in tool_calls:
+            name = call.get("function", {}).get("name")
+            arguments = call.get("function", {}).get("arguments", "{}")
+            tool_call_id = call.get("id") or "call-0"
+
+            try:
+                parsed_args = json.loads(arguments)
+            except json.JSONDecodeError:
+                parsed_args = {}
+
+            if name == "get_weather":
+                result = mock_weather(parsed_args.get("city", "Unknown"))
+            elif name == "search_docs":
+                result = mock_document_search(parsed_args.get("query", ""))
+            else:
+                result = {"error": f"Unhandled tool: {name}"}
+
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": json.dumps(result),
+                }
+            )
+
+
+if __name__ == "__main__":
+    run_agentic_demo()

--- a/static/downloads/python-basic.py
+++ b/static/downloads/python-basic.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Basic example: call the OpenAI-compatible worker for a friendly response."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+import requests
+
+DEFAULT_WORKER_URL = "https://your-worker-url.example.com"
+ENV_PATH = Path(__file__).resolve().parent / ".env"
+
+
+def ensure_env_file(path: Path = ENV_PATH) -> None:
+    """Ensure a .env file exists with WORKER_URL and WORKER_API_KEY keys."""
+    defaults: Dict[str, str] = {
+        "WORKER_URL": DEFAULT_WORKER_URL,
+        "WORKER_API_KEY": "",
+    }
+
+    if not path.exists():
+        path.write_text(
+            "# Environment settings for the OpenAI-compatible worker\n"
+            "WORKER_URL={url}\n"
+            "WORKER_API_KEY=\n".format(url=defaults["WORKER_URL"]),
+            encoding="utf-8",
+        )
+        return
+
+    existing_keys = {
+        line.split("=", 1)[0].strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line and not line.strip().startswith("#") and "=" in line
+    }
+
+    if "WORKER_URL" not in existing_keys or "WORKER_API_KEY" not in existing_keys:
+        with path.open("a", encoding="utf-8") as handle:
+            if "WORKER_URL" not in existing_keys:
+                handle.write(f"\nWORKER_URL={defaults['WORKER_URL']}")
+            if "WORKER_API_KEY" not in existing_keys:
+                handle.write("\nWORKER_API_KEY=")
+
+
+def load_env(path: Path = ENV_PATH) -> Dict[str, str]:
+    """Load the environment variables from the .env file."""
+    ensure_env_file(path)
+    values: Dict[str, str] = {}
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.strip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key.strip(), value)
+        values[key.strip()] = value
+
+    return values
+
+
+def call_worker(messages: list[dict[str, str]]) -> dict:
+    env_values = load_env()
+    worker_url = env_values.get("WORKER_URL", DEFAULT_WORKER_URL).rstrip("/")
+    api_key = env_values.get("WORKER_API_KEY")
+
+    if not api_key:
+        raise RuntimeError(
+            "WORKER_API_KEY is missing. Update the .env file next to this script with your worker API key."
+        )
+
+    endpoint = f"{worker_url}/v1/chat/completions"
+    response = requests.post(
+        endpoint,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": "@cf/meta/llama-4-scout-17b-16e-instruct",
+            "messages": messages,
+        },
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    messages = [
+        {"role": "system", "content": "You are a concise assistant."},
+        {"role": "user", "content": "Summarize what this worker can do in two sentences."},
+    ]
+
+    result = call_worker(messages)
+    try:
+        content = result["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
+        content = json.dumps(result, indent=2)
+
+    print("Response from worker:\n")
+    print(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/static/downloads/python-structured-llama4.py
+++ b/static/downloads/python-structured-llama4.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Request a structured response from the worker using Llama 4 Scout."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, Tuple
+
+import requests
+
+DEFAULT_WORKER_URL = "https://your-worker-url.example.com"
+ENV_PATH = Path(__file__).resolve().parent / ".env"
+
+
+def ensure_env_file(path: Path = ENV_PATH) -> None:
+    defaults: Dict[str, str] = {
+        "WORKER_URL": DEFAULT_WORKER_URL,
+        "WORKER_API_KEY": "",
+    }
+
+    if not path.exists():
+        path.write_text(
+            "# Environment settings for the OpenAI-compatible worker\n"
+            "WORKER_URL={url}\n"
+            "WORKER_API_KEY=\n".format(url=defaults["WORKER_URL"]),
+            encoding="utf-8",
+        )
+        return
+
+    existing_keys = {
+        line.split("=", 1)[0].strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line and not line.strip().startswith("#") and "=" in line
+    }
+
+    with path.open("a", encoding="utf-8") as handle:
+        if "WORKER_URL" not in existing_keys:
+            handle.write(f"\nWORKER_URL={defaults['WORKER_URL']}")
+        if "WORKER_API_KEY" not in existing_keys:
+            handle.write("\nWORKER_API_KEY=")
+
+
+def load_env(path: Path = ENV_PATH) -> Dict[str, str]:
+    ensure_env_file(path)
+    values: Dict[str, str] = {}
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.strip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        clean_value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key.strip(), clean_value)
+        values[key.strip()] = clean_value
+
+    return values
+
+
+def build_payload(city: str) -> Tuple[str, dict]:
+    schema = {
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"},
+            "summary": {"type": "string"},
+            "highlights": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 2,
+            },
+            "best_season": {"type": "string"},
+        },
+        "required": ["city", "summary", "highlights", "best_season"],
+        "additionalProperties": False,
+    }
+
+    payload = {
+        "model": "@cf/meta/llama-4-scout-17b-16e-instruct",
+        "messages": [
+            {"role": "system", "content": "You are a travel data generator."},
+            {
+                "role": "user",
+                "content": f"Create a JSON travel summary for {city}.",
+            },
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "travel_guide",
+                "schema": schema,
+            },
+        },
+    }
+    return city, payload
+
+
+def request_structured_response(city: str) -> dict:
+    env_values = load_env()
+    worker_url = env_values.get("WORKER_URL", DEFAULT_WORKER_URL).rstrip("/")
+    api_key = env_values.get("WORKER_API_KEY")
+
+    if not api_key:
+        raise RuntimeError("WORKER_API_KEY is missing. Populate it inside .env next to this script.")
+
+    _, payload = build_payload(city)
+    endpoint = f"{worker_url}/v1/chat/completions"
+    response = requests.post(
+        endpoint,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=90,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    city = "Lisbon"
+    result = request_structured_response(city)
+    message = result.get("choices", [{}])[0].get("message", {})
+    structured = message.get("parsed") or message.get("content")
+
+    if isinstance(structured, str):
+        try:
+            structured = json.loads(structured)
+        except json.JSONDecodeError:
+            print("Raw response:\n", structured)
+            return
+
+    print(json.dumps(structured, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/static/index.html
+++ b/static/index.html
@@ -101,6 +101,12 @@
             border-radius: 8px 8px 0 0;
         }
 
+        .nav a.nav-item {
+            text-decoration: none;
+            color: inherit;
+            display: inline-block;
+        }
+
         .nav-item:hover {
             background: #f5f5f5;
         }
@@ -142,6 +148,38 @@
             font-size: 0.9rem;
             line-height: 1.4;
             position: relative;
+        }
+
+        .tabbed-example {
+            margin: 20px 0 30px 0;
+        }
+
+        .tab-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 15px;
+        }
+
+        .tab-button {
+            background: rgba(102, 126, 234, 0.12);
+            border: 1px solid transparent;
+            border-radius: 8px;
+            padding: 8px 16px;
+            cursor: pointer;
+            font-weight: 600;
+            color: #444;
+            transition: all 0.3s ease;
+        }
+
+        .tab-button:hover {
+            background: rgba(102, 126, 234, 0.2);
+        }
+
+        .tab-button.active {
+            background: #667eea;
+            color: white;
+            box-shadow: 0 8px 16px rgba(102, 126, 234, 0.35);
         }
 
         .copy-btn {
@@ -559,6 +597,7 @@
                 <div class="nav-item" onclick="showSection('endpoints')">🔗 Endpoints</div>
                 <div class="nav-item" onclick="showSection('examples')">💡 Examples</div>
                 <div class="nav-item" onclick="showSection('auth')">🔐 Authentication</div>
+                <a class="nav-item" href="/downloads.html">⬇️ Download Modules</a>
             </div>
 
             <div id="overview" class="section active">
@@ -596,8 +635,9 @@
                 <p>
                     • <a href="/openapi.json" target="_blank">OpenAPI Specification</a><br>
                     • <a href="/health" target="_blank">Health Check</a><br>
-                    • <a href="https://docs.cloudflare.com/workers/">Cloudflare Workers Docs</a>
-                </p>
+                    • <a href="https://docs.cloudflare.com/workers/">Cloudflare Workers Docs</a><br>
+                    • <a href="https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/" target="_blank" rel="noopener noreferrer">Llama 4 Scout Model Docs</a>
+            </p>
             </div>
 
             <div id="tester" class="section">
@@ -829,6 +869,22 @@
             <div id="examples" class="section">
                 <h2>💡 Code Examples</h2>
 
+                <h3>Structured Responses with Llama 4</h3>
+                <p>Use <code>@cf/meta/llama-4-scout-17b-16e-instruct</code> for JSON-safe answers. Learn more in the <a href="https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/" target="_blank" rel="noopener noreferrer">official Workers AI documentation</a>.</p>
+                <div class="tabbed-example structured-example" data-default-lang="curl">
+                    <div class="tab-buttons">
+                        <button class="tab-button structured-tab active" data-lang="curl">curl</button>
+                        <button class="tab-button structured-tab" data-lang="python">python</button>
+                        <button class="tab-button structured-tab" data-lang="typescript">typescript</button>
+                        <button class="tab-button structured-tab" data-lang="javascript">javascript</button>
+                        <button class="tab-button structured-tab" data-lang="rest">rest api</button>
+                    </div>
+                    <div class="code-block">
+                        <button class="copy-btn" onclick="copyToClipboard(this)">Copy</button>
+                        <pre><code id="structured-example-code">Select a language to view an example.</code></pre>
+                    </div>
+                </div>
+
                 <h3>JavaScript / Node.js</h3>
                 <div class="code-block">
                     <button class="copy-btn" onclick="copyToClipboard(this)">Copy</button>
@@ -929,6 +985,233 @@ print(response.json()['choices'][0]['message']['content'])
     </div>
 
     <script>
+        const structuredResponseSnippets = {
+            curl: `curl -X POST [WORKER_URL]/v1/chat/completions \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer $WORKER_API_KEY" \\
+  -d '{
+    "model": "@cf/meta/llama-4-scout-17b-16e-instruct",
+    "messages": [
+      {"role": "system", "content": "You are a structured data generator."},
+      {"role": "user", "content": "Produce a travel brief for Lisbon."}
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "travel_guide",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string"},
+            "summary": {"type": "string"},
+            "highlights": {
+              "type": "array",
+              "items": {"type": "string"},
+              "minItems": 2
+            }
+          },
+          "required": ["city", "summary", "highlights"],
+          "additionalProperties": false
+        }
+      }
+    }
+  }'`,
+            python: `import json
+import os
+import requests
+
+worker_url = "[WORKER_URL]/v1/chat/completions"
+api_key = os.environ["WORKER_API_KEY"]
+
+payload = {
+    "model": "@cf/meta/llama-4-scout-17b-16e-instruct",
+    "messages": [
+        {"role": "system", "content": "Return JSON only."},
+        {"role": "user", "content": "Summarize Lisbon for a first-time visitor."}
+    ],
+    "response_format": {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "travel_plan",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "must_do": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 3
+                    }
+                },
+                "required": ["city", "summary", "must_do"],
+                "additionalProperties": False
+            }
+        }
+    }
+}
+
+response = requests.post(
+    worker_url,
+    headers={
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    },
+    json=payload,
+    timeout=60,
+)
+response.raise_for_status()
+print(json.dumps(response.json()["choices"][0]["message"].get("parsed"), indent=2))`,
+            typescript: `import type { ChatCompletion } from "openai";
+
+const workerUrl = "[WORKER_URL]";
+const apiKey = process.env.WORKER_API_KEY ?? "";
+
+async function structuredExample(): Promise<void> {
+  const endpoint = workerUrl + "/v1/chat/completions";
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer " + apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "@cf/meta/llama-4-scout-17b-16e-instruct",
+      messages: [
+        { role: "system", content: "Respond using JSON only." },
+        { role: "user", content: "Create a Lisbon itinerary with three highlights." },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "itinerary",
+          schema: {
+            type: "object",
+            properties: {
+              city: { type: "string" },
+              highlights: {
+                type: "array",
+                items: { type: "string" },
+                minItems: 3,
+              },
+              tip: { type: "string" },
+            },
+            required: ["city", "highlights", "tip"],
+          },
+        },
+      },
+    }),
+  });
+
+  const body = (await response.json()) as ChatCompletion;
+  console.log(body.choices[0].message?.parsed);
+}
+
+structuredExample().catch(console.error);`,
+            javascript: `const workerUrl = "[WORKER_URL]";
+const apiKey = process.env.WORKER_API_KEY || "";
+
+async function runStructuredExample() {
+  const res = await fetch(workerUrl + "/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer " + apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "@cf/meta/llama-4-scout-17b-16e-instruct",
+      messages: [
+        { role: "system", content: "Return JSON." },
+        { role: "user", content: "Share two food recommendations for Lisbon." },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "food_recs",
+          schema: {
+            type: "object",
+            properties: {
+              city: { type: "string" },
+              dishes: {
+                type: "array",
+                items: { type: "string" },
+                minItems: 2,
+              },
+            },
+            required: ["city", "dishes"],
+          },
+        },
+      },
+    }),
+  });
+
+  const data = await res.json();
+  console.log(data.choices[0].message?.parsed);
+}
+
+runStructuredExample().catch(console.error);`,
+            rest: `POST /v1/chat/completions HTTP/1.1
+Host: [WORKER_URL_HOST]
+Authorization: Bearer WORKER_API_KEY
+Content-Type: application/json
+
+{
+  "model": "@cf/meta/llama-4-scout-17b-16e-instruct",
+  "messages": [
+    { "role": "system", "content": "Return valid JSON." },
+    { "role": "user", "content": "Outline Lisbon highlights." }
+  ],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "lisbon_highlights",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string" },
+          "summary": { "type": "string" },
+          "spots": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 2
+          }
+        },
+        "required": ["city", "summary", "spots"]
+      }
+    }
+  }
+}`,
+        };
+
+        function initializeStructuredExampleTabs(origin) {
+            const container = document.querySelector('.structured-example');
+            if (!container) return;
+            const codeEl = container.querySelector('#structured-example-code');
+            const buttons = container.querySelectorAll('.structured-tab');
+            const resolvedSnippets = {};
+
+            Object.keys(structuredResponseSnippets).forEach(key => {
+                const snippet = structuredResponseSnippets[key]
+                    .replace(/\[WORKER_URL_HOST\]/g, origin.replace(/^https?:\/\//, ''))
+                    .replace(/\[WORKER_URL\]/g, origin);
+                resolvedSnippets[key] = snippet;
+            });
+
+            function setActive(lang) {
+                if (!resolvedSnippets[lang] || !codeEl) return;
+                buttons.forEach(btn => btn.classList.toggle('active', btn.dataset.lang === lang));
+                codeEl.textContent = resolvedSnippets[lang];
+                container.setAttribute('data-active-lang', lang);
+            }
+
+            buttons.forEach(btn => {
+                btn.addEventListener('click', () => setActive(btn.dataset.lang));
+            });
+
+            const defaultLang = container.getAttribute('data-default-lang') || 'curl';
+            setActive(defaultLang);
+        }
+
         let currentEndpoint = null;
         let chatHistory = [];
         let availableModels = []; // full /v1/models response
@@ -983,6 +1266,8 @@ print(response.json()['choices'][0]['message']['content'])
                 document.querySelectorAll('.code-block code').forEach(codeEl => {
                     codeEl.textContent = codeEl.textContent.replace(/\[WORKER_URL\]/g, currentOrigin);
                 });
+
+                initializeStructuredExampleTabs(currentOrigin);
 
                 // Wire initial UI events
                 document.getElementById('ai-service').addEventListener('change', onAIServiceChange);


### PR DESCRIPTION
## Summary
- add tabbed structured response examples for Llama 4 on the landing page with copy support and documentation links
- surface a downloads navigation entry with a new downloads.html page highlighting Python helper scripts
- provide four downloadable Python modules that bootstrap .env configuration and cover basic, structured, agentic, and advanced Worker AI usage patterns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efd39f11a8832ea87ac50d657c1fa3