### PR TITLE
Enforce auth and add request queue

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -28,7 +28,7 @@ export async function authenticateRequest(request: Request, env: Env): Promise<{
 	if (!authHeader.startsWith('Bearer ')) {
 		return { success: false, error: 'Invalid Authorization header format. Use: Bearer <token>' };
 	}
-        const token = authHeader.replace('Bearer ', '');
+	const token = authHeader.replace('Bearer ', '');
 
         if (!env.WORKER_API_KEY) {
                 errorLog('WORKER_API_KEY is not configured in the environment');

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,12 +6,12 @@
  *              Centralizing this logic makes the security model easier to manage and update.
  */
 
-import { debugLog } from './utils';
+import { debugLog, errorLog } from './utils';
 
 /**
  * Authenticates an incoming request based on the `Authorization` header.
  * It checks for the presence of a Bearer token and validates it against the
- * `WORKER_API_KEY` environment variable. In debug mode, this validation can be bypassed.
+ * `WORKER_API_KEY` environment variable.
  *
  * @param {Request} request - The incoming HTTP request object.
  * @param {Env} env - The worker's environment object, containing secrets and configuration.
@@ -28,19 +28,18 @@ export async function authenticateRequest(request: Request, env: Env): Promise<{
 	if (!authHeader.startsWith('Bearer ')) {
 		return { success: false, error: 'Invalid Authorization header format. Use: Bearer <token>' };
 	}
-	const token = authHeader.replace('Bearer ', '');
+        const token = authHeader.replace('Bearer ', '');
 
-	// In debug mode or if the API key is not set, bypass validation for development convenience.
-	if (env.DEBUG_LOGGING === 'true' || !env.WORKER_API_KEY) {
-		debugLog(env, 'Development mode: bypassing API key validation');
-		return { success: true };
-	}
+        if (!env.WORKER_API_KEY) {
+                errorLog('WORKER_API_KEY is not configured in the environment');
+                return { success: false, error: 'Service authentication is not configured' };
+        }
 
-	// Compare the provided token with the one stored in environment variables.
-	if (token !== env.WORKER_API_KEY) {
-		debugLog(env, 'API key validation failed');
-		return { success: false, error: 'Invalid API key' };
-	}
+        // Compare the provided token with the one stored in environment variables.
+        if (token !== env.WORKER_API_KEY) {
+                debugLog(env, 'API key validation failed');
+                return { success: false, error: 'Invalid API key' };
+        }
 
-	return { success: true };
+        return { success: true };
 }

--- a/src/handlers/cloudflare.ts
+++ b/src/handlers/cloudflare.ts
@@ -10,7 +10,7 @@
 import { saveMemoryContext } from '../memory';
 import { convertMessages } from '../models';
 import type { ChatCompletion } from 'openai/resources/chat/completions';
-import { debugLog, errorLog, generateId } from '../utils';
+import { debugLog, errorLog, generateId, logAIResponse, truncateForLog } from '../utils';
 
 /**
  * Handles a chat completion request directed to a Cloudflare AI model.
@@ -78,6 +78,7 @@ async function handleCloudflareRequest(params: any, env: Env, corsHeaders: Recor
             const { readable, writable } = new TransformStream();
             const writer = writable.getWriter();
             const encoder = new TextEncoder();
+            const decoder = new TextDecoder();
 
             const streamResponse = async () => {
                 const reader = responseStream.getReader();
@@ -85,6 +86,16 @@ async function handleCloudflareRequest(params: any, env: Env, corsHeaders: Recor
                     while (true) {
                         const { done, value } = await reader.read();
                         if (done) break;
+                        if (value) {
+                            try {
+                                const chunkText = decoder.decode(value, { stream: true });
+                                if (chunkText) {
+                                    debugLog(env, 'Cloudflare stream chunk', { preview: truncateForLog(chunkText) });
+                                }
+                            } catch (logError) {
+                                debugLog(env, 'Cloudflare stream chunk decode failed', { error: logError instanceof Error ? logError.message : 'Unknown decode error' });
+                            }
+                        }
                         await writer.write(value); // Pass through the Server-Sent Event chunks.
                     }
                     const finalChunk = `data: [DONE]\n\n`;
@@ -123,6 +134,8 @@ async function handleCloudflareRequest(params: any, env: Env, corsHeaders: Recor
                 }],
                 usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 } // Usage data not provided by Cloudflare AI.
             };
+
+            logAIResponse(env, 'Cloudflare', openaiResponse, { model: params.originalModel });
 
             return new Response(JSON.stringify(openaiResponse), {
                 headers: { 'Content-Type': 'application/json', ...corsHeaders }

--- a/src/handlers/gemini.ts
+++ b/src/handlers/gemini.ts
@@ -11,7 +11,7 @@ import { GoogleGenAI } from "@google/genai";
 import type { ChatCompletion } from 'openai/resources/chat/completions';
 import { saveMemoryContext } from '../memory';
 import type { ChatMessage } from '../types';
-import { debugLog, errorLog, generateId } from '../utils';
+import { debugLog, errorLog, generateId, logAIResponse, truncateForLog } from '../utils';
 import { convertOpenAISchemaToGemini } from '../models';
 
 /**
@@ -79,6 +79,7 @@ export async function handleGeminiRequest(params: any, env: Env, corsHeaders: Re
                     for await (const chunk of streamResult) {
                         const chunkText = chunk.text;
                         if (chunkText) {
+                            debugLog(env, 'Gemini stream chunk', { preview: truncateForLog(chunkText) });
                             const delta = {
                                 id: `chatcmpl-${generateId()}`,
                                 object: 'chat.completion.chunk',
@@ -86,9 +87,7 @@ export async function handleGeminiRequest(params: any, env: Env, corsHeaders: Re
                                 model: params.model,
                                 choices: [{ index: 0, delta: { content: chunkText }, finish_reason: null }]
                             };
-                            await writer.write(encoder.encode(`data: ${JSON.stringify(delta)}
-
-`));
+                            await writer.write(encoder.encode(`data: ${JSON.stringify(delta)}\n\n`));
                         }
                     }
 
@@ -131,6 +130,7 @@ export async function handleGeminiRequest(params: any, env: Env, corsHeaders: Re
                 choices: [{ index: 0, message: { role: 'assistant', content: text || null, refusal: null }, finish_reason: 'stop', logprobs: null }],
                 usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 } // Usage data not provided by Gemini
             };
+            logAIResponse(env, 'Gemini', openaiResponse, { model: params.model });
             return new Response(JSON.stringify(openaiResponse), { headers: { 'Content-Type': 'application/json', ...corsHeaders } });
         }
     } catch (error) {

--- a/src/handlers/openai.ts
+++ b/src/handlers/openai.ts
@@ -14,7 +14,7 @@
 
 import OpenAI from 'openai';
 import { saveMemoryContext } from '../memory';
-import { debugLog, errorLog, generateId } from '../utils';
+import { debugLog, errorLog, generateId, logAIResponse } from '../utils';
 
 // Minimal allowlist for json_schema-capable SKUs (expand if you confirm others)
 const JSON_SCHEMA_MODELS = [
@@ -128,6 +128,10 @@ export async function handleOpenAIRequest(params: any, env: Env, corsHeaders: Re
 
         const completion = await openai.chat.completions.create(apiParams);
 
+        if (params.stream) {
+            debugLog(env, 'OpenAI streaming response started', { model: modelId });
+        }
+
         // --- Normalize response when we used tools+strict fallback ---
         if (!supportsJsonSchema(modelId) && apiParams.tool_choice?.type === 'function') {
             const msg = (completion as any).choices?.[0]?.message;
@@ -149,6 +153,7 @@ export async function handleOpenAIRequest(params: any, env: Env, corsHeaders: Re
                 } else {
                     const responseText = cloned.choices[0]?.message?.content || '';
                     await saveMemoryContext(params.messages, responseText, params.memory_keyword, env);
+                    logAIResponse(env, 'OpenAI', cloned, { model: modelId, normalization: 'tools+strict' });
                     return new Response(JSON.stringify(cloned), {
                         headers: { 'Content-Type': 'application/json', ...corsHeaders }
                     });
@@ -164,6 +169,7 @@ export async function handleOpenAIRequest(params: any, env: Env, corsHeaders: Re
         } else {
             const responseText = (completion as any).choices[0]?.message?.content || '';
             await saveMemoryContext(params.messages, responseText, params.memory_keyword, env);
+            logAIResponse(env, 'OpenAI', completion, { model: modelId });
             return new Response(JSON.stringify(completion), {
                 headers: { 'Content-Type': 'application/json', ...corsHeaders }
             });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { authenticateRequest } from './auth';
 import { handleCompletions, handleCompletionsWithMemory, handleModelsRequest, handleTestAPIs } from './endpoints';
 import { handleChatCompletions, handleStructuredChatCompletions, handleTextChatCompletions, handleCodexRoute } from './routing';
 import { debugLog, errorLog, generateId } from './utils';
+import { getRequestQueue } from './request-queue';
 
 export default {
 	/**
@@ -98,6 +99,8 @@ export default {
 			}
                         debugLog(env, 'Authentication successful');
 
+                        const requestQueue = getRequestQueue(env);
+
                         const codexResponse = await handleCodexRoute(request, env, corsHeaders);
                         if (codexResponse) {
                                 return codexResponse;
@@ -105,25 +108,25 @@ export default {
 
                         // Route API requests to their respective handlers.
                         switch (path) {
-				case '/v1/chat/completions':
-					return handleChatCompletions(request, env, corsHeaders);
-				case '/v1/chat/completions/structured':
-					return handleStructuredChatCompletions(request, env, corsHeaders);
-				case '/v1/chat/completions/text':
-					return handleTextChatCompletions(request, env, corsHeaders);
-				case '/v1/models':
-					return handleModelsRequest(request, env, corsHeaders);
-				case '/v1/completions':
-					return handleCompletions(request, env, corsHeaders);
-				case '/v1/completions/withmemory':
-					return handleCompletionsWithMemory(request, env, corsHeaders);
-				case '/test/apis':
-					return handleTestAPIs(request, env, corsHeaders);
-				default:
-					return new Response(JSON.stringify({ error: { message: 'Not Found', type: 'invalid_request_error' } }), {
-						status: 404,
-						headers: { 'Content-Type': 'application/json', ...corsHeaders },
-					});
+                                case '/v1/chat/completions':
+                                        return requestQueue.enqueue(() => handleChatCompletions(request, env, corsHeaders));
+                                case '/v1/chat/completions/structured':
+                                        return requestQueue.enqueue(() => handleStructuredChatCompletions(request, env, corsHeaders));
+                                case '/v1/chat/completions/text':
+                                        return requestQueue.enqueue(() => handleTextChatCompletions(request, env, corsHeaders));
+                                case '/v1/models':
+                                        return requestQueue.enqueue(() => handleModelsRequest(request, env, corsHeaders));
+                                case '/v1/completions':
+                                        return requestQueue.enqueue(() => handleCompletions(request, env, corsHeaders));
+                                case '/v1/completions/withmemory':
+                                        return requestQueue.enqueue(() => handleCompletionsWithMemory(request, env, corsHeaders));
+                                case '/test/apis':
+                                        return requestQueue.enqueue(() => handleTestAPIs(request, env, corsHeaders));
+                                default:
+                                        return new Response(JSON.stringify({ error: { message: 'Not Found', type: 'invalid_request_error' } }), {
+                                                status: 404,
+                                                headers: { 'Content-Type': 'application/json', ...corsHeaders },
+                                        });
 			}
 
 		} catch (error) {

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -1,0 +1,85 @@
+/**
+ * @file src/request-queue.ts
+ * @description Provides a lightweight, in-memory request queue that limits the
+ *              number of concurrent AI provider calls. This helps the worker
+ *              gracefully handle bursts of requests without overwhelming the
+ *              upstream providers.
+ */
+
+const DEFAULT_CONCURRENCY = 6;
+const QUEUE_KEY = '__OPENAI_API_WORKER_REQUEST_QUEUE__';
+
+type Task<T> = () => Promise<T>;
+
+type QueueEntry<T> = {
+        task: Task<T>;
+        resolve: (value: T) => void;
+        reject: (reason?: unknown) => void;
+};
+
+class InternalRequestQueue {
+        private readonly queue: QueueEntry<unknown>[] = [];
+        private active = 0;
+
+        constructor(private readonly concurrencyLimit: number) {}
+
+        get concurrency(): number {
+                return this.concurrencyLimit;
+        }
+
+        enqueue<T>(task: Task<T>): Promise<T> {
+                return new Promise<T>((resolve, reject) => {
+                        const entry: QueueEntry<T> = { task, resolve, reject };
+                        this.queue.push(entry as QueueEntry<unknown>);
+                        this.process();
+                });
+        }
+
+        private process(): void {
+                while (this.active < this.concurrencyLimit && this.queue.length > 0) {
+                        const entry = this.queue.shift();
+                        if (!entry) {
+                                continue;
+                        }
+
+                        this.active++;
+                        Promise.resolve()
+                                .then(() => entry.task())
+                                .then((result) => entry.resolve(result))
+                                .catch((error) => entry.reject(error))
+                                .finally(() => {
+                                        this.active--;
+                                        this.process();
+                                });
+                }
+        }
+}
+
+type QueueHolder = { queue: InternalRequestQueue; concurrency: number };
+
+type GlobalWithQueue = typeof globalThis & {
+        [QUEUE_KEY]?: QueueHolder;
+};
+
+/**
+ * Returns a singleton instance of the request queue, creating it if needed.
+ * The concurrency level can be configured with the `REQUEST_CONCURRENCY`
+ * environment variable; otherwise, a sensible default is used.
+ */
+export function getRequestQueue(env: Env): InternalRequestQueue {
+        const configuredConcurrency = Number(env.REQUEST_CONCURRENCY);
+        const targetConcurrency = Number.isFinite(configuredConcurrency) && configuredConcurrency > 0
+                ? Math.floor(configuredConcurrency)
+                : DEFAULT_CONCURRENCY;
+
+        const globalRef = globalThis as GlobalWithQueue;
+        const existing = globalRef[QUEUE_KEY];
+
+        if (!existing || existing.concurrency !== targetConcurrency) {
+                const queue = new InternalRequestQueue(targetConcurrency);
+                globalRef[QUEUE_KEY] = { queue, concurrency: targetConcurrency };
+                return queue;
+        }
+
+        return existing.queue;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,12 +39,54 @@ export function debugLog(env: Env, message: string, data: Record<string, any> | 
  * @returns {void}
  */
 export function errorLog(message: string, error: any | null = null): void {
-	const timestamp = new Date().toISOString();
-	if (error) {
-		console.error(`[${timestamp}] ERROR: ${message}:`, error instanceof Error ? error.stack : JSON.stringify(error));
-	} else {
-		console.error(`[${timestamp}] ERROR: ${message}`);
-	}
+        const timestamp = new Date().toISOString();
+        if (error) {
+                console.error(`[${timestamp}] ERROR: ${message}:`, error instanceof Error ? error.stack : JSON.stringify(error));
+        } else {
+                console.error(`[${timestamp}] ERROR: ${message}`);
+        }
+}
+
+/**
+ * Truncates long strings so that verbose logs remain readable and avoid exceeding
+ * platform log limits.
+ *
+ * @param {string} value - The string value to truncate.
+ * @param {number} [maxLength=2000] - The maximum number of characters to retain.
+ * @returns {string} The truncated string with an indicator if it was shortened.
+ */
+export function truncateForLog(value: string, maxLength = 2000): string {
+        if (value.length <= maxLength) {
+                return value;
+        }
+
+        const trimmed = value.slice(0, maxLength);
+        return `${trimmed}\u2026 [truncated ${value.length - maxLength} chars]`;
+}
+
+/**
+ * Logs a provider response payload in a consistent, verbose manner while ensuring
+ * the payload remains log-friendly.
+ *
+ * @param {Env} env - The worker environment containing logging flags.
+ * @param {string} provider - The provider name used as a prefix for the log entry.
+ * @param {unknown} payload - The payload to log.
+ * @param {Record<string, unknown>} [context={}] - Additional context to include alongside the payload.
+ * @returns {void}
+ */
+export function logAIResponse(env: Env, provider: string, payload: unknown, context: Record<string, unknown> = {}): void {
+        try {
+                const serialized = typeof payload === 'string' ? payload : JSON.stringify(payload);
+                debugLog(env, `${provider} AI response`, {
+                        ...context,
+                        preview: truncateForLog(serialized),
+                });
+        } catch (error) {
+                debugLog(env, `${provider} AI response (serialization failed)`, {
+                        ...context,
+                        error: error instanceof Error ? error.message : 'Unknown serialization error',
+                });
+        }
 }
 
 /**

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,10 +8,11 @@ declare namespace Cloudflare {
 		BACKUP_MODEL: "@cf/openai/gpt-oss-120b";
 		WORKER_API_KEY: string;
 		CORE_WORKER_API_KEY: string;
-		DEBUG_LOGGING: string;
-		GEMINI_API_KEY: string;
-		OPENAI_API_KEY: string;
-		CORE_API: Fetcher /* core-api */;
+                DEBUG_LOGGING: string;
+                GEMINI_API_KEY: string;
+                OPENAI_API_KEY: string;
+                REQUEST_CONCURRENCY?: string;
+                CORE_API: Fetcher /* core-api */;
 		AI: Ai;
 		ASSETS: Fetcher;
 	}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,6 +30,7 @@ service = "core-api"
 # Default models configuration
 DEFAULT_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct"
 BACKUP_MODEL = "@cf/openai/gpt-oss-120b"
+REQUEST_CONCURRENCY = "6"
 
 # Environment-specific variables (set these using wrangler secret put)
 # WORKER_API_KEY = "your-secure-worker-api-key"


### PR DESCRIPTION
## Summary
- require configured API keys for all authenticated requests and improve logging helpers
- add verbose AI response logging across OpenAI, Gemini, and Cloudflare handlers
- introduce a configurable request queue to smooth traffic bursts and document the new setting

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68efdf56a0fc832ea5dfa20ae284abab