### PR TITLE
Add health endpoint test suite and frontend dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "test:post-deploy": "echo 'Running post-deployment tests...' && pnpm run test:worker-endpoints && pnpm run test:service-binding && pnpm run test:core-api",
     "test:service-binding": "node test/service-binding-test.js",
     "test:core-api": "node test/core-api-test.js",
+    "test:unit": "tsx --test test/unit/endpoints.test.ts",
     "deploy:staging": "npx wrangler deploy --env staging",
     "type-check": "tsc --noEmit -p .",
     "build": "tsc",
     "gemini-models": "tsx model_info/gemini-models.ts",
     "openai-models": "tsx model_info/openai-models.ts",
-    "cloudflare-models": "tsx model_info/cloudflare-models.ts"
+    "cloudflare-models": "tsx model_info/cloudflare-models.ts",
+    "deplo": "pnpm run test:unit && wrangler deploy"
   },
   "keywords": [
     "cloudflare",

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,312 @@
+/**
+ * @file src/health.ts
+ * @description Provides reusable endpoint unit tests that can be executed both
+ *              during automated test runs and dynamically from the `/health`
+ *              endpoint. The suite exercises every public API surface and
+ *              validates error handling paths so it can run safely without
+ *              external provider access. When an environment has all bindings
+ *              configured, the same suite will exercise live integrations.
+ */
+
+export type HealthTestStatus = 'pass' | 'fail';
+
+export interface EndpointTestResult {
+        name: string;
+        status: HealthTestStatus;
+        durationMs: number;
+        error?: string;
+        details?: Record<string, unknown>;
+}
+
+export interface EndpointHealthReport {
+        status: HealthTestStatus;
+        durationMs: number;
+        summary: {
+                total: number;
+                passed: number;
+                failed: number;
+        };
+        tests: EndpointTestResult[];
+}
+
+export interface HealthSuiteOptions {
+        baseUrl: string;
+        includeHealthEndpointTest?: boolean;
+}
+
+export type WorkerFetcher = (request: Request) => Promise<Response>;
+
+interface TestContext {
+        fetcher: WorkerFetcher;
+        env: Env;
+        baseUrl: string;
+        authHeader: string;
+}
+
+type TestDefinition = {
+        name: string;
+        run: (ctx: TestContext) => Promise<void>;
+};
+
+function buildAuthHeader(env: Env): string {
+        const token = env.WORKER_API_KEY || 'health-check-token';
+        return `Bearer ${token}`;
+}
+
+function createJsonRequest(url: string, body: unknown, authHeader: string): Request {
+        return new Request(url, {
+                method: 'POST',
+                headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: authHeader,
+                },
+                body: JSON.stringify(body),
+        });
+}
+
+async function expectOkJson(response: Response, errorMessage: string): Promise<any> {
+        if (!response.ok) {
+                throw new Error(`${errorMessage} (status ${response.status})`);
+        }
+        const text = await response.text();
+        try {
+                return JSON.parse(text);
+        } catch (error) {
+                throw new Error(`${errorMessage}: Failed to parse JSON - ${(error as Error).message}`);
+        }
+}
+
+function getTests(includeHealthEndpoint: boolean): TestDefinition[] {
+        const tests: TestDefinition[] = [
+                {
+                        name: 'Landing page available',
+                        run: async ({ fetcher, baseUrl }) => {
+                                const response = await fetcher(new Request(`${baseUrl}/`));
+                                if (!response.ok) {
+                                        throw new Error(`Expected 200 for landing page, got ${response.status}`);
+                                }
+                                const html = await response.text();
+                                if (!html.includes('<html')) {
+                                        throw new Error('Landing page did not return HTML content');
+                                }
+                        },
+                },
+                {
+                        name: 'OpenAPI specification available',
+                        run: async ({ fetcher, baseUrl }) => {
+                                const response = await fetcher(new Request(`${baseUrl}/openapi.json`));
+                                const data = await expectOkJson(response, 'Failed to load /openapi.json');
+                                if (!data.paths || typeof data.paths !== 'object') {
+                                        throw new Error('OpenAPI document missing `paths` definition');
+                                }
+                        },
+                },
+                {
+                        name: 'Models endpoint returns list',
+                        run: async ({ fetcher, baseUrl, authHeader }) => {
+                                const request = new Request(`${baseUrl}/v1/models`, {
+                                        headers: { Authorization: authHeader },
+                                });
+                                const data = await expectOkJson(await fetcher(request), 'Failed to query /v1/models');
+                                if (!Array.isArray(data.data)) {
+                                        throw new Error('Models response missing `data` array');
+                                }
+                        },
+                },
+                {
+                        name: 'Legacy completions validation errors',
+                        run: async ({ fetcher, baseUrl, authHeader }) => {
+                                const response = await fetcher(
+                                        createJsonRequest(
+                                                `${baseUrl}/v1/completions`,
+                                                { model: 'gpt-4o-mini' },
+                                                authHeader,
+                                        ),
+                                );
+                                if (response.status !== 400) {
+                                        throw new Error(`Expected 400 for missing prompt, received ${response.status}`);
+                                }
+                        },
+                },
+                {
+                        name: 'Chat completions validation errors',
+                        run: async ({ fetcher, baseUrl, authHeader }) => {
+                                const response = await fetcher(
+                                        createJsonRequest(
+                                                `${baseUrl}/v1/chat/completions`,
+                                                { model: '@cf/meta/llama-4-scout-17b-16e-instruct' },
+                                                authHeader,
+                                        ),
+                                );
+                                if (response.status !== 400) {
+                                        throw new Error(`Expected 400 for missing messages, received ${response.status}`);
+                                }
+                        },
+                },
+                {
+                        name: 'Text chat completions validation errors',
+                        run: async ({ fetcher, baseUrl, authHeader }) => {
+                                const response = await fetcher(
+                                        createJsonRequest(
+                                                `${baseUrl}/v1/chat/completions/text`,
+                                                { model: '@cf/meta/llama-4-scout-17b-16e-instruct' },
+                                                authHeader,
+                                        ),
+                                );
+                                if (response.status !== 400) {
+                                        throw new Error(`Expected 400 for missing messages, received ${response.status}`);
+                                }
+                        },
+                },
+                {
+                        name: 'Completions with memory validation errors',
+                        run: async ({ fetcher, baseUrl, authHeader }) => {
+                                const response = await fetcher(
+                                        createJsonRequest(
+                                                `${baseUrl}/v1/completions/withmemory`,
+                                                {
+                                                        model: '@cf/meta/llama-4-scout-17b-16e-instruct',
+                                                        memory: false,
+                                                },
+                                                authHeader,
+                                        ),
+                                );
+                                if (response.status !== 400) {
+                                        throw new Error(`Expected 400 for invalid memory flags, received ${response.status}`);
+                                }
+                        },
+                },
+                {
+                        name: 'Structured chat completions (llama-4)',
+                        run: async ({ fetcher, baseUrl, authHeader }) => {
+                                const response = await fetcher(
+                                        createJsonRequest(
+                                                `${baseUrl}/v1/chat/completions/structured`,
+                                                {
+                                                        model: '@cf/meta/llama-4-scout-17b-16e-instruct',
+                                                        messages: [
+                                                                { role: 'user', content: 'Return a JSON object with status and details.' },
+                                                        ],
+                                                        response_format: {
+                                                                type: 'json_schema',
+                                                                schema: {
+                                                                        name: 'HealthResponse',
+                                                                        schema: {
+                                                                                type: 'object',
+                                                                                properties: {
+                                                                                        status: { type: 'string' },
+                                                                                        details: { type: 'string' },
+                                                                                },
+                                                                                required: ['status'],
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                                authHeader,
+                                        ),
+                                );
+                                const completion = await expectOkJson(response, 'Structured completion failed');
+                                const content = completion?.choices?.[0]?.message?.content;
+                                if (typeof content !== 'string' || content.length === 0) {
+                                        throw new Error('Structured completion response missing assistant content');
+                                }
+                        },
+                },
+                {
+                        name: 'Provider diagnostics endpoint',
+                        run: async ({ fetcher, baseUrl, authHeader }) => {
+                                const request = new Request(`${baseUrl}/test/apis`, {
+                                        headers: { Authorization: authHeader },
+                                });
+                                const data = await expectOkJson(await fetcher(request), 'Diagnostics endpoint failed');
+                                if (!data.tests) {
+                                        throw new Error('Diagnostics response missing `tests` object');
+                                }
+                        },
+                },
+        ];
+
+        if (includeHealthEndpoint) {
+                tests.push({
+                        name: 'Health endpoint summary payload',
+                        run: async ({ fetcher, baseUrl }) => {
+                                const data = await expectOkJson(
+                                        await fetcher(new Request(`${baseUrl}/health`)),
+                                        'Health endpoint did not respond successfully',
+                                );
+                                if (!Array.isArray(data.tests)) {
+                                        throw new Error('Health endpoint response missing `tests` array');
+                                }
+                        },
+                });
+        }
+
+        return tests;
+}
+
+async function executeTest(test: TestDefinition, ctx: TestContext): Promise<EndpointTestResult> {
+        const start = Date.now();
+        try {
+                await test.run(ctx);
+                return {
+                        name: test.name,
+                        status: 'pass',
+                        durationMs: Date.now() - start,
+                };
+        } catch (error) {
+                return {
+                        name: test.name,
+                        status: 'fail',
+                        durationMs: Date.now() - start,
+                        error: error instanceof Error ? error.message : String(error),
+                };
+        }
+}
+
+/**
+ * Runs the full endpoint health suite using the provided fetcher and environment.
+ *
+ * @param fetcher - Function used to execute requests against the worker.
+ * @param env - The worker environment (used for auth token discovery).
+ * @param options - Suite execution options.
+ */
+export async function runEndpointHealthChecks(
+        fetcher: WorkerFetcher,
+        env: Env,
+        options: HealthSuiteOptions,
+): Promise<EndpointHealthReport> {
+        const suiteStart = Date.now();
+        const tests = getTests(options.includeHealthEndpointTest ?? false);
+        const context: TestContext = {
+                fetcher,
+                env,
+                baseUrl: options.baseUrl,
+                authHeader: buildAuthHeader(env),
+        };
+
+        const results: EndpointTestResult[] = [];
+        for (const test of tests) {
+                // Execute sequentially to avoid overwhelming bindings during health checks.
+                const result = await executeTest(test, context);
+                results.push(result);
+        }
+
+        const summary = results.reduce(
+                (acc, result) => {
+                        acc.total += 1;
+                        if (result.status === 'pass') acc.passed += 1;
+                        else acc.failed += 1;
+                        return acc;
+                },
+                { total: 0, passed: 0, failed: 0 },
+        );
+
+        const status: HealthTestStatus = summary.failed > 0 ? 'fail' : 'pass';
+
+        return {
+                status,
+                durationMs: Date.now() - suiteStart,
+                summary,
+                tests: results,
+        };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,133 +14,130 @@
 
 import { authenticateRequest } from './auth';
 import { handleCompletions, handleCompletionsWithMemory, handleModelsRequest, handleTestAPIs } from './endpoints';
+import { runEndpointHealthChecks } from './health';
 import { handleChatCompletions, handleStructuredChatCompletions, handleTextChatCompletions, handleCodexRoute } from './routing';
 import { debugLog, errorLog, generateId } from './utils';
 
-export default {
-	/**
-	 * The main fetch handler for the Cloudflare Worker.
-	 * This function is executed for every incoming HTTP request.
-	 *
-	 * @param {Request} request - The incoming request object.
-	 * @param {Env} env - The environment object containing bindings and variables.
-	 * @returns {Promise<Response>} A promise that resolves to the response to be sent to the client.
-	 */
-	async fetch(request: Request, env: Env): Promise<Response> {
-		const url = new URL(request.url);
-		const path = url.pathname;
-
-		debugLog(env, `Incoming request: ${request.method} ${path}`);
-
-		// Define CORS headers for preflight (OPTIONS) and actual requests.
-		const corsHeaders: Record<string, string> = {
-			'Access-Control-Allow-Origin': '*',
-			'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-			'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-		};
-
-		if (request.method === 'OPTIONS') {
-			debugLog(env, 'Handling CORS preflight request');
-			return new Response(null, { headers: corsHeaders });
-		}
-
-		try {
-            // A map of public routes that do not require authentication.
-            const publicRoutes: Record<string, string> = {
-                '/': '/index.html',
-                '/index.html': '/index.html',
-                '/openapi.json': '/openapi.json',
-                '/test-dropdowns.html': '/test-dropdowns.html',
-                '/debug-test.html': '/debug-test.html',
-                '/quick-test.html': '/quick-test.html',
-                '/cloudflare_ai_models.json': '/cloudflare_ai_models.json',
-            };
-
-            if (publicRoutes[path]) {
-                debugLog(env, `Serving static asset: ${publicRoutes[path]}`);
-                try {
-                    // Use the ASSETS binding to fetch static files.
-                    const asset = await env.ASSETS.fetch(new URL(request.url).origin + publicRoutes[path]);
-                    const contentType = path.endsWith('.json') ? 'application/json' : 'text/html';
-                    return new Response(asset.body, {
-                        headers: { 'Content-Type': contentType, ...corsHeaders },
-                    });
-                } catch (error) {
-                    errorLog(`Error serving static asset: ${path}`, error);
-                    return new Response(`Not Found: ${path}`, { status: 404, headers: corsHeaders });
-                }
-            }
-
-			// Health check endpoint for monitoring.
-			if (path === '/health') {
-				debugLog(env, 'Health check requested');
-				return new Response(JSON.stringify({
-					status: 'healthy',
-					service: 'openai-api-worker',
-					timestamp: new Date().toISOString(),
-					version: '2.1.0',
-					providers: {
-						cloudflare: true,
-						openai: !!env.OPENAI_API_KEY,
-						gemini: !!env.GEMINI_API_KEY
-					}
-				}), { headers: { 'Content-Type': 'application/json', ...corsHeaders } });
-			}
-
-			// Authenticate all other API requests.
-			const authResult = await authenticateRequest(request, env);
-			if (!authResult.success) {
-				errorLog(`Authentication failed: ${authResult.error}`);
-				return new Response(JSON.stringify({ error: { message: authResult.error, type: 'invalid_request_error' } }), {
-					status: 401,
-					headers: { 'Content-Type': 'application/json', ...corsHeaders },
-				});
-			}
-                        debugLog(env, 'Authentication successful');
-
-                        const codexResponse = await handleCodexRoute(request, env, corsHeaders);
-                        if (codexResponse) {
-                                return codexResponse;
-                        }
-
-                        // Route API requests to their respective handlers.
-                        switch (path) {
-				case '/v1/chat/completions':
-					return handleChatCompletions(request, env, corsHeaders);
-				case '/v1/chat/completions/structured':
-					return handleStructuredChatCompletions(request, env, corsHeaders);
-				case '/v1/chat/completions/text':
-					return handleTextChatCompletions(request, env, corsHeaders);
-				case '/v1/models':
-					return handleModelsRequest(request, env, corsHeaders);
-				case '/v1/completions':
-					return handleCompletions(request, env, corsHeaders);
-				case '/v1/completions/withmemory':
-					return handleCompletionsWithMemory(request, env, corsHeaders);
-				case '/test/apis':
-					return handleTestAPIs(request, env, corsHeaders);
-				default:
-					return new Response(JSON.stringify({ error: { message: 'Not Found', type: 'invalid_request_error' } }), {
-						status: 404,
-						headers: { 'Content-Type': 'application/json', ...corsHeaders },
-					});
-			}
-
-		} catch (error) {
-			// Global error handler for any unhandled exceptions.
-			errorLog('Unhandled worker error', error);
-			const errorResponse = {
-				error: {
-					message: 'Internal Server Error',
-					type: 'server_error',
-					details: error instanceof Error ? error.message : 'Unknown error',
-					request_id: generateId()
-				}
-			};
-			return new Response(JSON.stringify(errorResponse), {
-				status: 500,
-				headers: { 'Content-Type': 'application/json', ...corsHeaders },
-			});
-		}
-	},
+const PUBLIC_ROUTES: Record<string, string> = {
+        '/': '/index.html',
+        '/index.html': '/index.html',
+        '/openapi.json': '/openapi.json',
+        '/health.html': '/health.html',
+        '/test-dropdowns.html': '/test-dropdowns.html',
+        '/debug-test.html': '/debug-test.html',
+        '/quick-test.html': '/quick-test.html',
+        '/cloudflare_ai_models.json': '/cloudflare_ai_models.json',
 };
+
+const CORS_HEADERS: Record<string, string> = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+/**
+ * Shared handler for all incoming requests.
+ * Exported separately to make it easy to reuse in unit tests and health checks.
+ */
+export async function handleRequest(request: Request, env: Env): Promise<Response> {
+        const url = new URL(request.url);
+        const path = url.pathname;
+
+        debugLog(env, `Incoming request: ${request.method} ${path}`);
+
+        if (request.method === 'OPTIONS') {
+                debugLog(env, 'Handling CORS preflight request');
+                return new Response(null, { headers: CORS_HEADERS });
+        }
+
+        try {
+                if (PUBLIC_ROUTES[path]) {
+                        debugLog(env, `Serving static asset: ${PUBLIC_ROUTES[path]}`);
+                        try {
+                                const asset = await env.ASSETS.fetch(new URL(request.url).origin + PUBLIC_ROUTES[path]);
+                                const contentType = path.endsWith('.json') ? 'application/json' : 'text/html';
+                                return new Response(asset.body, {
+                                        headers: { 'Content-Type': contentType, ...CORS_HEADERS },
+                                });
+                        } catch (error) {
+                                errorLog(`Error serving static asset: ${path}`, error);
+                                return new Response(`Not Found: ${path}`, { status: 404, headers: CORS_HEADERS });
+                        }
+                }
+
+                if (path === '/health') {
+                        debugLog(env, 'Health check requested');
+                        const report = await runEndpointHealthChecks(
+                                (req: Request) => handleRequest(req, env),
+                                env,
+                                {
+                                        baseUrl: url.origin,
+                                        includeHealthEndpointTest: false,
+                                },
+                        );
+
+                        return new Response(JSON.stringify({
+                                status: report.status,
+                                service: 'openai-api-worker',
+                                version: '2.1.0',
+                                timestamp: new Date().toISOString(),
+                                durationMs: report.durationMs,
+                                summary: report.summary,
+                                tests: report.tests,
+                        }), { headers: { 'Content-Type': 'application/json', ...CORS_HEADERS } });
+                }
+
+                const authResult = await authenticateRequest(request, env);
+                if (!authResult.success) {
+                        errorLog(`Authentication failed: ${authResult.error}`);
+                        return new Response(JSON.stringify({ error: { message: authResult.error, type: 'invalid_request_error' } }), {
+                                status: 401,
+                                headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+                        });
+                }
+                debugLog(env, 'Authentication successful');
+
+                const codexResponse = await handleCodexRoute(request, env, CORS_HEADERS);
+                if (codexResponse) {
+                        return codexResponse;
+                }
+
+                switch (path) {
+                        case '/v1/chat/completions':
+                                return handleChatCompletions(request, env, CORS_HEADERS);
+                        case '/v1/chat/completions/structured':
+                                return handleStructuredChatCompletions(request, env, CORS_HEADERS);
+                        case '/v1/chat/completions/text':
+                                return handleTextChatCompletions(request, env, CORS_HEADERS);
+                        case '/v1/models':
+                                return handleModelsRequest(request, env, CORS_HEADERS);
+                        case '/v1/completions':
+                                return handleCompletions(request, env, CORS_HEADERS);
+                        case '/v1/completions/withmemory':
+                                return handleCompletionsWithMemory(request, env, CORS_HEADERS);
+                        case '/test/apis':
+                                return handleTestAPIs(request, env, CORS_HEADERS);
+                        default:
+                                return new Response(JSON.stringify({ error: { message: 'Not Found', type: 'invalid_request_error' } }), {
+                                        status: 404,
+                                        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+                                });
+                }
+        } catch (error) {
+                errorLog('Unhandled worker error', error);
+                const errorResponse = {
+                        error: {
+                                message: 'Internal Server Error',
+                                type: 'server_error',
+                                details: error instanceof Error ? error.message : 'Unknown error',
+                                request_id: generateId(),
+                        },
+                };
+                return new Response(JSON.stringify(errorResponse), {
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+                });
+        }
+}
+
+export default { fetch: handleRequest };

--- a/static/health.html
+++ b/static/health.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Service Health & Unit Tests</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background: linear-gradient(135deg, #2b5876 0%, #4e4376 100%);
+            color: #f7fafc;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 40px 20px 80px;
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        header h1 {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+        }
+
+        header p {
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .card {
+            background: rgba(15, 22, 36, 0.9);
+            border-radius: 16px;
+            padding: 24px;
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+            margin-bottom: 24px;
+        }
+
+        .actions {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        button {
+            background: #63b3ed;
+            color: #0f1724;
+            border: none;
+            border-radius: 8px;
+            padding: 10px 20px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 8px 20px rgba(99, 179, 237, 0.35);
+        }
+
+        button[disabled] {
+            cursor: wait;
+            opacity: 0.6;
+            box-shadow: none;
+        }
+
+        .status-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            background: rgba(99, 179, 237, 0.1);
+            border: 1px solid rgba(99, 179, 237, 0.3);
+            border-radius: 999px;
+            padding: 6px 14px;
+            color: #bee3f8;
+            font-weight: 600;
+        }
+
+        .status-chip.fail {
+            background: rgba(252, 129, 129, 0.1);
+            border-color: rgba(252, 129, 129, 0.3);
+            color: #fed7d7;
+        }
+
+        .results {
+            margin-top: 24px;
+            display: grid;
+            gap: 16px;
+        }
+
+        .result-item {
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        .result-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .result-name {
+            font-weight: 600;
+            color: #edf2f7;
+        }
+
+        .result-error {
+            margin-top: 10px;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            color: #fed7d7;
+        }
+
+        .summary {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-top: 18px;
+            color: rgba(237, 242, 247, 0.9);
+        }
+
+        a.back-link {
+            color: #90cdf4;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        a.back-link:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <header>
+            <h1>Service Health &amp; Unit Tests</h1>
+            <p>Run the same endpoint unit tests used in CI directly from the browser. Results stream from the
+                real worker in real-time so you can verify every route, including structured Llama 4 completions.</p>
+        </header>
+
+        <div class="card">
+            <div class="actions">
+                <button id="run-tests">Run Unit Tests</button>
+                <span id="status-chip" class="status-chip">Idle</span>
+                <a class="back-link" href="/">← Back to documentation</a>
+            </div>
+            <div class="summary" id="summary"></div>
+            <div class="results" id="results"></div>
+        </div>
+    </div>
+
+    <script>
+        const runButton = document.getElementById('run-tests');
+        const resultsContainer = document.getElementById('results');
+        const statusChip = document.getElementById('status-chip');
+        const summaryContainer = document.getElementById('summary');
+
+        function setStatus(status, text) {
+            statusChip.classList.remove('fail');
+            if (status === 'fail') {
+                statusChip.classList.add('fail');
+            }
+            statusChip.textContent = text;
+        }
+
+        function renderSummary(report) {
+            summaryContainer.innerHTML = '';
+            const fragments = [
+                `Total: ${report.summary.total}`,
+                `Passed: ${report.summary.passed}`,
+                `Failed: ${report.summary.failed}`,
+                `Duration: ${Math.round(report.durationMs)} ms`
+            ];
+            fragments.forEach(text => {
+                const span = document.createElement('span');
+                span.textContent = text;
+                summaryContainer.appendChild(span);
+            });
+        }
+
+        function renderResults(tests) {
+            resultsContainer.innerHTML = '';
+            tests.forEach(test => {
+                const item = document.createElement('div');
+                item.className = 'result-item';
+
+                const header = document.createElement('div');
+                header.className = 'result-header';
+
+                const name = document.createElement('span');
+                name.className = 'result-name';
+                name.textContent = test.name;
+
+                const badge = document.createElement('span');
+                badge.className = `status-chip ${test.status === 'fail' ? 'fail' : ''}`;
+                badge.textContent = `${test.status.toUpperCase()} • ${Math.round(test.durationMs)} ms`;
+
+                header.appendChild(name);
+                header.appendChild(badge);
+                item.appendChild(header);
+
+                if (test.error) {
+                    const error = document.createElement('div');
+                    error.className = 'result-error';
+                    error.textContent = test.error;
+                    item.appendChild(error);
+                }
+
+                resultsContainer.appendChild(item);
+            });
+        }
+
+        async function runTests() {
+            runButton.disabled = true;
+            setStatus('running', 'Running…');
+            summaryContainer.innerHTML = '';
+            resultsContainer.innerHTML = '';
+
+            try {
+                const response = await fetch('/health');
+                const report = await response.json();
+
+                setStatus(report.status, report.status === 'pass' ? 'All tests passed' : 'Tests failed');
+                renderSummary(report);
+                renderResults(report.tests);
+            } catch (error) {
+                setStatus('fail', 'Unable to fetch results');
+                const item = document.createElement('div');
+                item.className = 'result-item';
+                item.innerHTML = `<div class="result-error">${error instanceof Error ? error.message : String(error)}</div>`;
+                resultsContainer.appendChild(item);
+            } finally {
+                runButton.disabled = false;
+            }
+        }
+
+        runButton.addEventListener('click', runTests);
+    </script>
+</body>
+
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -596,6 +596,7 @@
                 <div class="nav-item" onclick="showSection('test')">🔍 API Tests</div>
                 <div class="nav-item" onclick="showSection('endpoints')">🔗 Endpoints</div>
                 <div class="nav-item" onclick="showSection('examples')">💡 Examples</div>
+                <a class="nav-item" href="/health.html">❤️ Health &amp; Unit Tests</a>
                 <div class="nav-item" onclick="showSection('auth')">🔐 Authentication</div>
                 <a class="nav-item" href="/downloads.html">⬇️ Download Modules</a>
             </div>
@@ -634,7 +635,7 @@
                 <h3>📚 Resources</h3>
                 <p>
                     • <a href="/openapi.json" target="_blank">OpenAPI Specification</a><br>
-                    • <a href="/health" target="_blank">Health Check</a><br>
+                    • <a href="/health.html" target="_blank">Interactive Health &amp; Unit Test Dashboard</a><br>
                     • <a href="https://docs.cloudflare.com/workers/">Cloudflare Workers Docs</a><br>
                     • <a href="https://developers.cloudflare.com/workers-ai/models/llama-4-scout-17b-16e-instruct/" target="_blank" rel="noopener noreferrer">Llama 4 Scout Model Docs</a>
             </p>

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -160,26 +160,88 @@
     "/health": {
       "get": {
         "summary": "Health check",
-        "description": "Returns the health status of the API",
+        "description": "Runs the full endpoint unit-test suite (including structured Llama 4 requests) and returns live results.",
         "responses": {
           "200": {
-            "description": "Health status",
+            "description": "Detailed health status with test results",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "status",
+                    "service",
+                    "version",
+                    "timestamp",
+                    "summary",
+                    "tests"
+                  ],
                   "properties": {
                     "status": {
                       "type": "string",
-                      "example": "healthy"
+                      "enum": ["pass", "fail"],
+                      "example": "pass"
                     },
                     "service": {
                       "type": "string",
                       "example": "openai-api-worker"
                     },
+                    "version": {
+                      "type": "string",
+                      "example": "2.1.0"
+                    },
                     "timestamp": {
                       "type": "string",
                       "format": "date-time"
+                    },
+                    "durationMs": {
+                      "type": "number",
+                      "description": "Total time spent running the health suite"
+                    },
+                    "summary": {
+                      "type": "object",
+                      "required": ["total", "passed", "failed"],
+                      "properties": {
+                        "total": {
+                          "type": "integer",
+                          "example": 9
+                        },
+                        "passed": {
+                          "type": "integer",
+                          "example": 9
+                        },
+                        "failed": {
+                          "type": "integer",
+                          "example": 0
+                        }
+                      }
+                    },
+                    "tests": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": ["name", "status", "durationMs"],
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "example": "Structured chat completions (llama-4)"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": ["pass", "fail"],
+                            "example": "pass"
+                          },
+                          "durationMs": {
+                            "type": "number",
+                            "example": 120
+                          },
+                          "error": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Error details when a test fails"
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/test/unit/endpoints.test.ts
+++ b/test/unit/endpoints.test.ts
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runEndpointHealthChecks } from '../../src/health';
+import { handleRequest } from '../../src/index';
+import type { Env } from '../../src/types';
+
+type MemoryStore = Map<string, string>;
+
+function createMemoryBinding(): Env['AI_MEMORY'] {
+        const store: MemoryStore = new Map();
+        return {
+                async get(key: string) {
+                        return store.get(key) ?? null;
+                },
+                async put(key: string, value: string) {
+                        store.set(key, value);
+                },
+                async delete(key: string) {
+                        store.delete(key);
+                },
+                async list({ prefix }: { prefix: string }) {
+                        const keys = Array.from(store.keys())
+                                .filter((key) => key.startsWith(prefix))
+                                .map((name) => ({ name }));
+                        return { keys };
+                },
+        } as Env['AI_MEMORY'];
+}
+
+function createAssetsBinding(): Env['ASSETS'] {
+        return {
+                async fetch(input: RequestInfo | URL) {
+                        const url = new URL(typeof input === 'string' ? input : input instanceof Request ? input.url : input.toString());
+                        const path = url.pathname;
+                        if (path === '/index.html') {
+                                return new Response('<html><body>Test Landing</body></html>', {
+                                        headers: { 'Content-Type': 'text/html' },
+                                });
+                        }
+                        if (path === '/openapi.json') {
+                                return new Response(JSON.stringify({ openapi: '3.1.0', paths: {} }), {
+                                        headers: { 'Content-Type': 'application/json' },
+                                });
+                        }
+                        if (path === '/health.html') {
+                                return new Response('<html><body>Health Page</body></html>', {
+                                        headers: { 'Content-Type': 'text/html' },
+                                });
+                        }
+                        return new Response('Not found', { status: 404 });
+                },
+        } as Env['ASSETS'];
+}
+
+function createStubEnv(): Env {
+        const env = {
+                DEBUG_LOGGING: 'true',
+                WORKER_API_KEY: 'test-key',
+                DEFAULT_MODEL: '@cf/meta/llama-4-scout-17b-16e-instruct',
+                BACKUP_MODEL: '@cf/openai/gpt-oss-120b',
+                AI: {
+                        async run() {
+                                return {
+                                        response: 'Structured response from stub AI',
+                                };
+                        },
+                },
+                CORE_API: {
+                        async fetch() {
+                                return new Response(
+                                        JSON.stringify({ providers: { meta: [{ id: '@cf/meta/llama-4-scout-17b-16e-instruct', task: { name: 'text' } }] } }),
+                                        { headers: { 'Content-Type': 'application/json' } },
+                                );
+                        },
+                },
+                ASSETS: createAssetsBinding(),
+                AI_MEMORY: createMemoryBinding(),
+        } as unknown as Env;
+
+        return env;
+}
+
+function createFetcher(env: Env) {
+        return (request: Request) => handleRequest(request, env);
+}
+
+const BASE_URL = 'https://unit.test';
+
+test('endpoint health suite passes with stub environment', async () => {
+        const env = createStubEnv();
+        const fetcher = createFetcher(env);
+        const report = await runEndpointHealthChecks(fetcher, env, {
+                baseUrl: BASE_URL,
+                includeHealthEndpointTest: true,
+        });
+
+        assert.equal(report.status, 'pass', 'Health suite should pass for stub env');
+        assert.equal(report.summary.failed, 0);
+        assert(report.summary.total >= 8, 'Expected at least 8 health tests to run');
+
+        const structuredTest = report.tests.find((t) => t.name.includes('Structured chat completions'));
+        assert(structuredTest, 'Structured test should exist');
+        assert.equal(structuredTest.status, 'pass');
+});
+
+test('health endpoint returns report payload', async () => {
+        const env = createStubEnv();
+        const response = await handleRequest(new Request(`${BASE_URL}/health`), env);
+        assert.equal(response.status, 200);
+
+        const payload = await response.json();
+        assert.equal(typeof payload.status, 'string');
+        assert(Array.isArray(payload.tests));
+        assert(payload.summary.total >= payload.summary.passed);
+});


### PR DESCRIPTION
## Summary
- add a reusable endpoint health test suite and invoke it from the `/health` route
- expose unit test results through a dedicated `/static/health.html` dashboard and update the landing page/OpenAPI spec
- add `pnpm run test:unit` plus a deployment helper that runs tests before `wrangler deploy`

## Testing
- pnpm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68efdad6e5d4832e8c40e0ef1d41c5b4