### PR TITLE
Fix static asset error handling to preserve status codes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,10 +54,27 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
                 if (PUBLIC_ROUTES[path]) {
                         debugLog(env, `Serving static asset: ${PUBLIC_ROUTES[path]}`);
                         try {
-                                const asset = await env.ASSETS.fetch(new URL(request.url).origin + PUBLIC_ROUTES[path]);
-                                const contentType = path.endsWith('.json') ? 'application/json' : 'text/html';
-                                return new Response(asset.body, {
-                                        headers: { 'Content-Type': contentType, ...CORS_HEADERS },
+                                const assetResponse = await env.ASSETS.fetch(new URL(request.url).origin + PUBLIC_ROUTES[path]);
+                                const headers = new Headers(assetResponse.headers);
+
+                                // Ensure consistent CORS headers for all static responses.
+                                for (const [key, value] of Object.entries(CORS_HEADERS)) {
+                                        headers.set(key, value);
+                                }
+
+                                // Override the content type for HTML/JSON assets if not already set on successful responses.
+                                if (assetResponse.ok) {
+                                        if (path.endsWith('.json')) {
+                                                headers.set('Content-Type', 'application/json');
+                                        } else if (!headers.has('Content-Type')) {
+                                                headers.set('Content-Type', 'text/html');
+                                        }
+                                }
+
+                                return new Response(assetResponse.body, {
+                                        status: assetResponse.status,
+                                        statusText: assetResponse.statusText,
+                                        headers,
                                 });
                         } catch (error) {
                                 errorLog(`Error serving static asset: ${path}`, error);

--- a/test/unit/endpoints.test.ts
+++ b/test/unit/endpoints.test.ts
@@ -114,3 +114,20 @@ test('health endpoint returns report payload', async () => {
         assert(Array.isArray(payload.tests));
         assert(payload.summary.total >= payload.summary.passed);
 });
+
+test('static asset errors preserve original status code', async () => {
+        const env = createStubEnv();
+        env.ASSETS = {
+                async fetch() {
+                        return new Response('<!DOCTYPE html><title>Not Found</title>', {
+                                status: 404,
+                                headers: { 'Content-Type': 'text/html' },
+                        });
+                },
+        } as Env['ASSETS'];
+
+        const response = await handleRequest(new Request(`${BASE_URL}/openapi.json`), env);
+        assert.equal(response.status, 404);
+        const body = await response.text();
+        assert.ok(body.includes('Not Found'));
+});


### PR DESCRIPTION
## Summary
- preserve the original status and headers when proxying static assets so missing files no longer appear successful
- add a unit test to guard the static asset error behaviour

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68efe0b4aa1c832e8d209b78f4e9a94b